### PR TITLE
Manage mongo lock retries

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python bot.py
+web: python bot.py

--- a/bot.py
+++ b/bot.py
@@ -638,7 +638,13 @@ async def admin_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
 def main():
     """פונקציה ראשית"""
-    # ניהול נעילת MongoDB למניעת ריצה מרובה
+    # הפעלת Flask בחוט נפרד מוקדם כדי לוודא שפורט נפתח עבור Render
+    flask_thread = threading.Thread(target=run_flask)
+    flask_thread.daemon = True
+    flask_thread.start()
+    logger.info("Flask server started")
+
+    # ניהול נעילת MongoDB למניעת ריצה מרובה (לאחר פתיחת הפורט)
     manage_mongo_lock()
     
     if not BOT_TOKEN:
@@ -647,12 +653,6 @@ def main():
     
     if not OWNER_CHAT_ID:
         logger.warning("OWNER_CHAT_ID לא מוגדר - לא תתקבלנה הודעות")
-    
-    # הפעלת Flask בחוט נפרד
-    flask_thread = threading.Thread(target=run_flask)
-    flask_thread.daemon = True
-    flask_thread.start()
-    logger.info("Flask server started")
     
     # יצירת האפליקציה + הסרת webhook בתוך ה-loop של PTB באמצעות post_init
     application = (


### PR DESCRIPTION
Configure the bot as a web service and start the Flask server first to resolve "No open ports detected" warnings on Render.

The service was previously configured as a web service on Render but did not explicitly listen on the provided `$PORT` environment variable. This caused Render to log "No open ports detected" warnings and potentially restart the service, contributing to MongoDB lock contention. This change ensures Flask starts and listens on the port before other bot operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-a331cfed-5ffb-411e-9dd8-090bbc3f542c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a331cfed-5ffb-411e-9dd8-090bbc3f542c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

